### PR TITLE
Fix responsive design issue in index2.html - Replace float layout with Flexbox

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -7,13 +7,28 @@
   <style>
     .container {
       width: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      padding: 20px;
+      box-sizing: border-box;
     }
 
     .card {
-      width: 50%;
+      flex: 1 1 300px;
       padding: 20px;
       border: 1px solid #ccc;
-      float: left;
+      border-radius: 8px;
+      background-color: #f9f9f9;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    /* Media query for small screens */
+    @media (max-width: 768px) {
+      .card {
+        flex: 1 1 100%;
+        margin-bottom: 15px;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
Issue
Cards in index2.html remained side-by-side on mobile, causing cramped layout.

Solution
- Replaced `float: left` with modern Flexbox layout
- Added media query for mobile responsiveness
- Cards now stack vertically on small screens

Testing
 Mobile: Cards stack vertically
 Desktop: Cards display side-by-side
 No horizontal scrolling on mobile

Screenshot of the change in UI:
![1](https://github.com/user-attachments/assets/9ceadd74-d256-4f6d-855d-cf2a53cd927c)
![2](https://github.com/user-attachments/assets/efd178cb-d1ba-43fa-b09e-a46b3ac00865)

